### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,15 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/support": "^12.2",
+        "php": "^8.3",
+        "illuminate/support": "^12.2 || ^13.0",
         "php-mime-mail-parser/php-mime-mail-parser": "^9.0"
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "larastan/larastan": "^3.2",
+        "larastan/larastan": "^3.9",
         "pestphp/pest": "^3.7",
-        "orchestra/testbench": "^10.1"
+        "orchestra/testbench": "^10.1 || ^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Widen `illuminate/support` from `^12.2` to `^12.2 || ^13.0`
- Bump PHP minimum from `^8.2` to `^8.3` (required by Laravel 13)
- Update dev deps: `orchestra/testbench` to `^10.1 || ^11.0`, `larastan/larastan` to `^3.9`

## Test plan
- [ ] Run `composer install` with Laravel 12 and 13 to verify dependency resolution
- [ ] Run test suite against each Laravel version

🤖 Generated with [Claude Code](https://claude.com/claude-code)